### PR TITLE
feat: add workflow to sync public forks

### DIFF
--- a/.github/workflows/sync-forks.yml
+++ b/.github/workflows/sync-forks.yml
@@ -1,0 +1,31 @@
+---
+# This workflow synchronizes all public forks associated with the provided
+# Personal Access Token (PAT). It is triggered manually or runs daily.
+# Note: The PAT requires the 'repo' scope (classic PAT) to function correctly.
+# By piping the list of repositories into a loop, the workflow logs each
+# synced repository and emits a warning if a synchronization fails,
+# without aborting the entire job.
+name: Sync Forks
+
+"on":
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sync all public forks
+        env:
+          # A classic Personal Access Token with the 'repo' scope is required
+          GH_TOKEN: ${{ secrets.PAT }}
+        run: |
+          gh repo list --fork --public --limit 999 \
+            --json nameWithOwner -q '.[].nameWithOwner' | \
+          while read -r repo; do
+            if [ -n "$repo" ]; then
+              echo "Syncing $repo..."
+              gh repo sync "$repo" || echo "::warning::Failed to sync $repo"
+            fi
+          done


### PR DESCRIPTION
Adds a new GitHub Actions workflow `.github/workflows/sync-forks.yml` to automatically sync public forks with their upstream repositories.

The workflow is triggered by `workflow_dispatch` (manual) and a daily `cron` schedule. 
It improves upon a basic `xargs` one-liner by piping the list of public forks directly into a `while read` loop. This allows the script to explicitly log the repository being synced, gracefully handle empty outputs, and emit warnings instead of breaking the entire job if a specific repository fails to sync. Furthermore, it inlines the `jq` query inside the initial GitHub CLI command to keep code simple and well within `yamllint` guidelines, and provides documentation at the top of the workflow file explaining its purpose and explicitly mentioning the required `repo` scope for the classic PAT.

---
*PR created automatically by Jules for task [1183595160513226703](https://jules.google.com/task/1183595160513226703) started by @iloveitaly*